### PR TITLE
Fix NullpointerException and ClassNotFoundException exceptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	include "io.github.cottonmc:Jankson-Fabric:2.0.0+j1.2.0"
 	include "io.github.cottonmc.cotton:cotton-logging:1.0.0-rc.4"
 	include "io.github.cottonmc.cotton:cotton-config:1.0.0-rc.7"
+	include "org.apache.commons:commons-compress:1.8.1"
 
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.

--- a/src/main/java/net/szum123321/textile_backup/core/BackupHelper.java
+++ b/src/main/java/net/szum123321/textile_backup/core/BackupHelper.java
@@ -43,7 +43,10 @@ public class BackupHelper {
 
         StringBuilder builder = new StringBuilder();
         builder.append("Backup started by: ");
-        builder.append(ctx.getName());
+        if( ctx != null )
+            builder.append(ctx.getName());
+        else
+            builder.append("SERVER");
         builder.append(" on: ");
         builder.append(getDateTimeFormatter().format(now));
 


### PR DESCRIPTION
Fix following exceptions on a linux fresh minecraft server with fabric 0.7.6+build.179

Fix NullPointer exception when server stop (ctx is null when BackupHelper.create is called by net.szum123321.textile_backup.mixin.MinecraftServerMixin#onShutdown)

Fix ClassNotFoundException exception for IOUtils class by adding dependency to org.apache.commons:commons-compress:1.8.1