### PR TITLE
Add backup delay option for broadcast announcement

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/net/szum123321/textile_backup/Statics.java
+++ b/src/main/java/net/szum123321/textile_backup/Statics.java
@@ -18,7 +18,7 @@
 
 package net.szum123321.textile_backup;
 
-import net.szum123321.textile_backup.core.restore.AwaitThread;
+import net.szum123321.textile_backup.core.AwaitThread;
 
 import java.io.File;
 import java.time.format.DateTimeFormatter;

--- a/src/main/java/net/szum123321/textile_backup/config/ConfigPOJO.java
+++ b/src/main/java/net/szum123321/textile_backup/config/ConfigPOJO.java
@@ -146,6 +146,11 @@ public class ConfigPOJO implements ConfigData {
     @ConfigEntry.Category("Manage")
     public boolean broadcastBackupStart = true;
 
+    @Comment("\nDelay in seconds between backup lag warning message and actual backup/lag start\n")
+    @ConfigEntry.Gui.Tooltip()
+    @ConfigEntry.Category("Manage")
+    public int broadcastBackupDelayStart = 20;
+
     @Comment("\nAnnounce to ALL players when backup finishes\n")
     @ConfigEntry.Gui.NoTooltip()
     @ConfigEntry.Category("Manage")

--- a/src/main/java/net/szum123321/textile_backup/core/AwaitThread.java
+++ b/src/main/java/net/szum123321/textile_backup/core/AwaitThread.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-package net.szum123321.textile_backup.core.restore;
+package net.szum123321.textile_backup.core;
 
 import net.szum123321.textile_backup.TextileBackup;
 import net.szum123321.textile_backup.TextileLogger;
@@ -48,7 +48,7 @@ public class AwaitThread extends Thread {
         try {
             Thread.sleep(delay * 1000L);
         } catch (InterruptedException e) {
-            log.info("Backup restoration cancelled.");
+            log.info("Backup thread cancelled.");
             return;
         }
 
@@ -57,6 +57,6 @@ public class AwaitThread extends Thread {
             But still it's farewell
             And maybe we'll come back
          */
-        new Thread(taskRunnable, "Textile Backup restore thread nr. " + thisThreadId).start();
+        new Thread(taskRunnable, "Textile Backup task thread nr. " + thisThreadId).start();
     }
 }

--- a/src/main/java/net/szum123321/textile_backup/core/create/MakeBackupRunnable.java
+++ b/src/main/java/net/szum123321/textile_backup/core/create/MakeBackupRunnable.java
@@ -48,6 +48,34 @@ public class MakeBackupRunnable implements Runnable {
     @Override
     public void run() {
         try {
+            StringBuilder builder = new StringBuilder();
+
+            builder.append("Backup started ");
+
+            builder.append(context.getInitiator().getPrefix());
+
+            if(context.startedByPlayer())
+                builder.append(context.getCommandSource().getDisplayName().getString());
+            else
+                builder.append(context.getInitiator().getName());
+
+            builder.append(" on: ");
+            builder.append(Utilities.getDateTimeFormatter().format(LocalDateTime.now()));
+
+            log.info(builder.toString());
+
+            if (context.shouldSave()) {
+                log.sendInfoAL(context, "Saving server...");
+
+                context.getServer().getPlayerManager().saveAllPlayerData();
+
+                try {
+                    context.getServer().save(false, true, true);
+                } catch (Exception e) {
+                    log.sendErrorAL(context,"An exception occurred when trying to save the world!");
+                }
+            }
+
             Utilities.disableWorldSaving(context.getServer());
             Statics.disableWatchdog = true;
 

--- a/src/main/java/net/szum123321/textile_backup/core/restore/RestoreHelper.java
+++ b/src/main/java/net/szum123321/textile_backup/core/restore/RestoreHelper.java
@@ -25,6 +25,7 @@ import net.szum123321.textile_backup.config.ConfigHelper;
 import net.szum123321.textile_backup.config.ConfigPOJO;
 import net.szum123321.textile_backup.Statics;
 import net.szum123321.textile_backup.core.ActionInitiator;
+import net.szum123321.textile_backup.core.AwaitThread;
 import net.szum123321.textile_backup.core.Utilities;
 import org.jetbrains.annotations.NotNull;
 


### PR DESCRIPTION
This patch adds the config option `broadcastBackupDelayStart` which allows setting a delay in seconds before actually starting the backup after the warning broadcast. 

This should allow players to prepare for a huge lag.