### PR TITLE
Add replacment of reserved filename chars from comment

### DIFF
--- a/src/main/java/net/szum123321/textile_backup/core/create/MakeBackupRunnable.java
+++ b/src/main/java/net/szum123321/textile_backup/core/create/MakeBackupRunnable.java
@@ -134,7 +134,7 @@ public class MakeBackupRunnable implements Runnable {
         LocalDateTime now = LocalDateTime.now();
 
         return Utilities.getDateTimeFormatter().format(now) +
-                (context.getComment() != null ? "#" + context.getComment().replace("#", "") : "") +
+                (context.getComment() != null ? "#" + context.getComment().replaceAll("[\\\\/:*?\"<>|#]", "") : "") +
                 config.get().format.getCompleteString();
     }
 }


### PR DESCRIPTION
Currently, including an invalid filename character in a backup comment can cause unintended behavior (e.g. a comment with a / in it on linux will create the backup inside a nested folder). This change simply changes the existing replacement of #'s within comments into a replacement of any invalid characters.