### PR TITLE
Add ability to backup entire game/server root (+config) (bump to 2.4.0)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,6 @@ lazydfu_version=0.1.2
 pgzip_commit_hash=af5f5c297e735f3f2df7aa4eb0e19a5810b8aff6
 
 # Mod Properties
-mod_version = 2.3.1-a
+mod_version = 2.4.0
 maven_group = net.szum123321
 archives_base_name = textile_backup

--- a/src/main/java/net/szum123321/textile_backup/config/ConfigPOJO.java
+++ b/src/main/java/net/szum123321/textile_backup/config/ConfigPOJO.java
@@ -64,13 +64,24 @@ public class ConfigPOJO implements ConfigData {
 
     @Comment("\nA path to the backup folder\n")
     @ConfigEntry.Gui.NoTooltip()
-    public String path = "backup/";
+    public String path = "backup";
+
+    @Comment("""
+            \nShould the entire game folder be backed up?
+            In singleplayer, the entire game folder will be the .minecraft folder
+            (including all resource packs, saves, etc!)
+            In a server, it will be the server root.
+            If disabled, this mod will only backup the world.
+            """)
+    @ConfigEntry.Gui.Tooltip()
+    @ConfigEntry.Category("Create")
+    public boolean backupWholeGameDir = false;
 
     @Comment("""
             \nThis setting allows you to exclude files form being backed-up.
             Be very careful when setting it, as it is easy corrupt your world!
             """)
-    @ConfigEntry.Gui.NoTooltip()
+    @ConfigEntry.Gui.Tooltip()
     @ConfigEntry.Category("Create")
     public List<String> fileBlacklist = new ArrayList<>();
 

--- a/src/main/java/net/szum123321/textile_backup/core/Utilities.java
+++ b/src/main/java/net/szum123321/textile_backup/core/Utilities.java
@@ -60,14 +60,20 @@ public class Utilities {
 	}
 
 	public static String getLevelName(MinecraftServer server) {
+		if (config.get().backupWholeGameDir) return ".";
+
 		return 	((MinecraftServerSessionAccessor)server).getSession().getDirectoryName();
 	}
 
 	public static File getWorldFolder(MinecraftServer server) {
-		return ((MinecraftServerSessionAccessor)server)
+		if (config.get().backupWholeGameDir) {
+			return server.getRunDirectory();
+		} else {
+			return ((MinecraftServerSessionAccessor)server)
 				.getSession()
 				.getWorldDirectory(World.OVERWORLD)
 				.toFile();
+		}
 	}
 	
 	public static File getBackupRootPath(String worldName) {
@@ -121,6 +127,10 @@ public class Utilities {
 		if(isWindows()) { //hotfix!
 			if (path.getFileName().toString().equals("session.lock")) return true;
 		}
+
+		// dont back up the backup folder
+		String absPath = new File(path.toString()).getAbsolutePath();
+		if (absPath.startsWith(new File(config.get().path).getAbsolutePath())) return true;
 
 		return config.get().fileBlacklist.stream().anyMatch(path::startsWith);
 	}

--- a/src/main/resources/assets/textile_backup/lang/en_us.json
+++ b/src/main/resources/assets/textile_backup/lang/en_us.json
@@ -26,7 +26,11 @@
 
   "text.autoconfig.textile_backup.option.path": "Path to backup folder",
 
+  "text.autoconfig.textile_backup.option.backupWholeGameDir": "Backup entire game folder",
+  "text.autoconfig.textile_backup.option.backupWholeGameDir.@Tooltip": "Should the entire game folder be backed up?\nIn singleplayer, the entire game folder will be the .minecraft folder\n(including all resource packs, saves, etc!)\nIn a server, it will be the server root.\nIf disabled, this mod will only backup the world.",
+
   "text.autoconfig.textile_backup.option.fileBlacklist": "Blacklisted files",
+  "text.autoconfig.textile_backup.option.fileBlacklist.@Tooltip": "The backup folder is automatically excluded.",
 
   "text.autoconfig.textile_backup.option.deleteOldBackupAfterRestore": "Delete restored backup",
 


### PR DESCRIPTION
Adds an option to either backup just the world folder (like normal, default) or the entire server/game root (for servers, but also usable in client). Also exclude backup folder to prevent chaos.

Bump to 2.4.0.

(yes i did test this on client and server)