### PR TITLE
Btrfs snapshot support

### DIFF
--- a/src/main/java/net/szum123321/textile_backup/config/ConfigPOJO.java
+++ b/src/main/java/net/szum123321/textile_backup/config/ConfigPOJO.java
@@ -18,11 +18,14 @@
 
 package net.szum123321.textile_backup.config;
 
+import com.sun.jna.Native;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
 import me.shedaniel.autoconfig.annotation.ConfigEntry;
 import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.Comment;
 import net.szum123321.textile_backup.TextileBackup;
+import net.szum123321.textile_backup.core.btrfs.BtrfsUtil;
+import net.szum123321.textile_backup.core.btrfs.BtrfsUtilJnaInterface;
 
 import java.time.format.DateTimeFormatter;
 import java.util.*;
@@ -115,6 +118,7 @@ public class ConfigPOJO implements ConfigData {
             BZIP2 - tar.bz2 archive using bzip2 compression
             LZMA - tar.xz using lzma compression
             TAR - .tar with no compression
+            BTRFS_SNAPSHOT - btrfs snapshot name as the whole directory
             """)
     @ConfigEntry.Gui.Tooltip()
     @ConfigEntry.Category("Create")
@@ -173,6 +177,9 @@ public class ConfigPOJO implements ConfigData {
                     e
                     );
         }
+
+        if(format == ArchiveFormat.BTRFS_SNAPSHOT)
+           BtrfsUtil.buInterface = Native.load("btrfsutil", BtrfsUtilJnaInterface.class);
     }
 
     public enum ArchiveFormat {
@@ -180,7 +187,8 @@ public class ConfigPOJO implements ConfigData {
         GZIP("tar", "gz"),
         BZIP2("tar", "bz2"),
         LZMA("tar", "xz"),
-        TAR("tar");
+        TAR("tar"),
+        BTRFS_SNAPSHOT("snap");
 
         private final List<String> extensionPieces;
 

--- a/src/main/java/net/szum123321/textile_backup/core/Utilities.java
+++ b/src/main/java/net/szum123321/textile_backup/core/Utilities.java
@@ -69,7 +69,7 @@ public class Utilities {
 				.getWorldDirectory(World.OVERWORLD)
 				.toFile();
 	}
-	
+
 	public static File getBackupRootPath(String worldName) {
 		File path = new File(config.get().path).getAbsoluteFile();
 
@@ -81,6 +81,8 @@ public class Utilities {
 	}
 
 	public static void updateTMPFSFlag(MinecraftServer server) {
+		if(config.get().format== ConfigPOJO.ArchiveFormat.BTRFS_SNAPSHOT)
+			return;
 		boolean flag = false;
 		Path tmp_dir = Path.of(System.getProperty("java.io.tmpdir"));
 		if(
@@ -177,7 +179,7 @@ public class Utilities {
 	}
 
 	public static boolean isFileOk(File f) {
-		return f.exists() && f.isFile();
+		return f.exists() && (f.isFile() || (config.get().format == ConfigPOJO.ArchiveFormat.BTRFS_SNAPSHOT && f.isDirectory()));
 	}
 
 	public static DateTimeFormatter getDateTimeFormatter() {

--- a/src/main/java/net/szum123321/textile_backup/core/btrfs/BtrfsSnapshotHelper.java
+++ b/src/main/java/net/szum123321/textile_backup/core/btrfs/BtrfsSnapshotHelper.java
@@ -1,0 +1,24 @@
+package net.szum123321.textile_backup.core.btrfs;
+
+import net.szum123321.textile_backup.TextileBackup;
+import net.szum123321.textile_backup.TextileLogger;
+import net.szum123321.textile_backup.core.ActionInitiator;
+import net.szum123321.textile_backup.core.create.BackupContext;
+
+import java.io.File;
+
+public class BtrfsSnapshotHelper {
+    private final static TextileLogger log = new TextileLogger(TextileBackup.MOD_NAME);
+
+    public static void createSnapshot(File inputFile, File outputFile, BackupContext ctx) {
+        if (BtrfsUtil.isSubVol(inputFile)) {
+            if (!BtrfsUtil.createSnapshot(inputFile, outputFile)) {
+                if (ctx != null && ctx.getInitiator() == ActionInitiator.Player)
+                    log.sendError(ctx, "Failed to create snapshot.");
+                else log.error("Failed to create snapshot.");
+            }
+        } else if (ctx != null && ctx.getInitiator() == ActionInitiator.Player)
+            log.sendError(ctx, "The world folder is not in a btrfs subvolume. Backup canceled.");
+        else log.error("The world folder is not in a btrfs subvolume. Backup canceled.");
+    }
+}

--- a/src/main/java/net/szum123321/textile_backup/core/btrfs/BtrfsUtil.java
+++ b/src/main/java/net/szum123321/textile_backup/core/btrfs/BtrfsUtil.java
@@ -1,0 +1,23 @@
+package net.szum123321.textile_backup.core.btrfs;
+
+import java.io.File;
+
+public class BtrfsUtil {
+    public static BtrfsUtilJnaInterface buInterface;
+
+
+    public static boolean isSubVol(File file) {
+        int ret = buInterface.btrfs_util_is_subvolume(file.toString());
+        return ret == 0;
+    }
+
+    public static boolean createSnapshot(File source, File dest) {
+        buInterface.btrfs_util_create_snapshot(source.toString(), dest.toString(), 0, null, null);
+        return isSubVol(dest);
+    }
+
+    public static boolean deleteSubVol(File file) {
+        buInterface.btrfs_util_delete_subvolume(file.toString(), 0);
+        return !file.exists();
+    }
+}

--- a/src/main/java/net/szum123321/textile_backup/core/btrfs/BtrfsUtilJnaInterface.java
+++ b/src/main/java/net/szum123321/textile_backup/core/btrfs/BtrfsUtilJnaInterface.java
@@ -1,0 +1,10 @@
+package net.szum123321.textile_backup.core.btrfs;
+
+import com.sun.jna.Library;
+
+public interface BtrfsUtilJnaInterface extends Library {
+    int btrfs_util_is_subvolume(String path, Object... args);
+    void btrfs_util_create_subvolume(String path, Object... args);
+    void btrfs_util_create_snapshot(String source, String destination, Object... args);
+    void btrfs_util_delete_subvolume(String path, Object... args);
+}


### PR DESCRIPTION
Some sort of `btrfs` snapshot support. I was writing [BtrBack](https://github.com/himekifee/BtrBack) and found it too complicated to redo everything so I wrote some changes to support the functionality in this mod. For now, it uses `jna` and require host to have lib `libbtrfsutil`. I may do something like [python-btrfs](https://github.com/knorrie/python-btrfs) to support `btrfs` manipulation natively later. Should not break any functionality before adding this.